### PR TITLE
Handle quote key

### DIFF
--- a/cons.js
+++ b/cons.js
@@ -26,12 +26,13 @@ addchar(c)
 }
 
 function
-specialchar(c)
+specialchar(shift, c)
 {
 	switch(c) {
 	case 42: keybuf = 4; break;
 	case 19: keybuf = 034; break;
 	case 46: keybuf = 127; break;
+	case 222: keybuf = shift ? 042 : 047; break;
 	default: return;
 	}
 	TKS |= 0x80;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 		<span id="ips"> </span>
 		<span id="rkbusy" style='display: none'>hard disk busy</span>
 		<div>press run, type <tt>unix</tt> at the <tt>@</tt> prompt to load the kernel, enjoy! <a href="http://aiju.de/code/pdp11/faq">faq</a></div>
-		<textarea id="terminal" readonly="readonly" onkeypress="addchar(event.which)" onkeyup="specialchar(event.which)"> </textarea>
+		<textarea id="terminal" readonly="readonly" onkeypress="addchar(event.which)" onkeyup="specialchar(event.shiftKey, event.which)"> </textarea>
 		<textarea id="debug" readonly="readonly"> </textarea>
 	</body>
 </html>


### PR DESCRIPTION
And differentiate simple and double by checking the shift modifier.

Was trying to write a hello world program and couldn't get the double quotes. This should make it possible.

Tested on latest Chrome, Firefox and Safari.